### PR TITLE
Fixed formally wrong backpropagation/gradient descent

### DIFF
--- a/nn.py
+++ b/nn.py
@@ -32,11 +32,13 @@ for epoch in range(epochs):
         nr_correct += int(np.argmax(o) == np.argmax(l))
 
         # Backpropagation output -> hidden (cost function derivative)
-        delta_o = o - l
-        w_h_o += -learn_rate * delta_o @ np.transpose(h)
-        b_h_o += -learn_rate * delta_o
+        delta_o = (o - l)*o*(1-o)
+
         # Backpropagation hidden -> input (activation function derivative)
         delta_h = np.transpose(w_h_o) @ delta_o * (h * (1 - h))
+	#update weights
+        w_h_o += -learn_rate * delta_o @ np.transpose(h)
+        b_h_o += -learn_rate * delta_o
         w_i_h += -learn_rate * delta_h @ np.transpose(img)
         b_i_h += -learn_rate * delta_h
 


### PR DESCRIPTION
The calculation of the gradient is missing the derivative of the sigmoid function for the outer layer and the weights of the hidden layer were updated in a way that affects the update of the weight of the input layer. This is not formally correct (though I imagine the latter probably works in a lot of cases if you do small enough steps). The former probably only works because the sigmoid function is strictly increasing.